### PR TITLE
Displaying the RSSI of connected devices

### DIFF
--- a/lib/bluetooth/connection.dart
+++ b/lib/bluetooth/connection.dart
@@ -53,6 +53,16 @@ class Connection {
       }
     };
     UniversalBle.onScanResult = (result) {
+      // Update RSSI for already connected devices
+      final existingDevice = devices.firstOrNullWhere(
+        (e) => e is BluetoothDevice && e.device.deviceId == result.deviceId,
+      );
+      if (existingDevice != null && existingDevice is BluetoothDevice) {
+        existingDevice.rssi = result.rssi;
+        _connectionStreams.add(existingDevice); // Notify UI of update
+        return;
+      }
+
       if (_lastScanResult.none((e) => e.deviceId == result.deviceId)) {
         _lastScanResult.add(result);
 

--- a/lib/bluetooth/devices/bluetooth_device.dart
+++ b/lib/bluetooth/devices/bluetooth_device.dart
@@ -22,10 +22,13 @@ abstract class BluetoothDevice extends BaseDevice {
   final BleDevice scanResult;
 
   BluetoothDevice(this.scanResult, {required super.availableButtons, super.isBeta = false})
-    : super(scanResult.name ?? 'Unknown Device');
+    : super(scanResult.name ?? 'Unknown Device') {
+    rssi = scanResult.rssi;
+  }
 
   int? batteryLevel;
   String? firmwareVersion;
+  int? rssi;
 
   static List<String> servicesToScan = [
     ZwiftConstants.ZWIFT_CUSTOM_SERVICE_UUID,
@@ -157,6 +160,21 @@ abstract class BluetoothDevice extends BaseDevice {
           style: TextStyle(fontWeight: FontWeight.bold),
         ),
         if (isBeta) BetaPill(),
+        if (rssi != null) ...[
+          Padding(
+            padding: const EdgeInsets.only(left: 8.0),
+            child: Icon(
+              switch (rssi!) {
+                >= -50 => Icons.signal_cellular_4_bar,
+                >= -60 => Icons.signal_cellular_alt_2_bar,
+                >= -70 => Icons.signal_cellular_alt_1_bar,
+                _ => Icons.signal_cellular_alt,
+              },
+              size: 18,
+            ),
+          ),
+          Text('$rssi dBm'),
+        ],
         if (batteryLevel != null) ...[
           Icon(switch (batteryLevel!) {
             >= 80 => Icons.battery_full,


### PR DESCRIPTION
It would be really useful if the RSSI was displayed where the battery and firmware version are already shown:

<img width="390" height="105" alt="Image" src="https://github.com/user-attachments/assets/05310f2b-3451-4698-8843-e830d14f28bf" />

This works only because we are scanning in the background and therefore obtaining new RSSI values. However, I have read somewhere that some devices stop reporting RSSI values or scan results when actively connected. I tested with the Zwift Play, and there, the proposed implementation works without issue.

We are limited to this approach because currently, `universal_ble` only provides RSSI values through scan results (`BleDevice.rssi`). Once a device is connected, there's no way to read the current RSSI value directly.

Since we already use a fork, we could improve this by extending the library so it exposes the RSSI of the active connections. According to Claude, this is possible on macOS, Windows, Android, Linux, but not on Web Bluetooth yet. On Android, this would be done using `gatt.readRemoteRssi()`.