### PR TITLE
fix: Windows same-host mDNS discovery + surface received mDNS queries in diagnostics

### DIFF
--- a/lib/services/debug_diagnostics.dart
+++ b/lib/services/debug_diagnostics.dart
@@ -3,6 +3,7 @@ import 'dart:io' show Platform;
 import 'package:bike_control/main.dart' show recordError;
 import 'package:bike_control/services/mdns_discovery_scan.dart';
 import 'package:flutter/foundation.dart';
+import 'package:prop/mdns/mdns_responder.dart' show MdnsQueryLogEntry;
 import 'package:prop/mdns/service_advertiser.dart';
 import 'package:prop/utils/advertised_service_registry.dart';
 import 'package:prop/utils/network_address.dart';
@@ -53,6 +54,10 @@ class DebugDiagnostics {
   final List<TcpServerInfo> servers;
   final PermissionsSnapshot permissions;
 
+  /// mDNS queries our responder saw. Empty on the nsd backend (iOS), where the
+  /// OS responder handles queries and never tells us about them.
+  final List<MdnsQueryLogEntry> recentQueries;
+
   const DebugDiagnostics({
     required this.advertised,
     required this.backend,
@@ -63,6 +68,7 @@ class DebugDiagnostics {
     required this.addressReport,
     required this.servers,
     required this.permissions,
+    this.recentQueries = const [],
   });
 
   static Future<DebugDiagnostics> gather({
@@ -119,6 +125,7 @@ class DebugDiagnostics {
       addressReport: addressReport,
       servers: servers,
       permissions: permissions,
+      recentQueries: isResponder ? advertiser.recentQueries : const [],
     );
   }
 
@@ -165,6 +172,22 @@ class DebugDiagnostics {
         if (c.isVirtual) 'virtual',
       ];
       b.writeln('    ${c.interfaceName}/${c.address} = ${c.score}${tags.isEmpty ? '' : ' (${tags.join(', ')})'}');
+    }
+
+    // "Did the trainer app on this machine ask us anything, and did we answer?"
+    // A same-host querier shows up with the advertised address as its source.
+    // No entries at all means the failure is upstream of this responder.
+    b.writeln('  mDNS queries received:');
+    if (recentQueries.isEmpty) {
+      b.writeln('    (none)');
+    } else {
+      for (final q in recentQueries) {
+        final at = q.at.toIso8601String().split('T').last.split('.').first;
+        b.writeln(
+          '    $at ${q.source}:${q.sourcePort} ${q.wantsUnicast ? 'QU' : 'QM'} '
+          '${q.questions.join(', ')} → ${q.reply}',
+        );
+      }
     }
 
     b.writeln('  TCP servers:');

--- a/test/services/debug_diagnostics_test.dart
+++ b/test/services/debug_diagnostics_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:bike_control/services/debug_diagnostics.dart';
 import 'package:bike_control/services/mdns_discovery_scan.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:prop/mdns/mdns_responder.dart' show MdnsQueryLogEntry;
 import 'package:prop/utils/advertised_service_registry.dart';
 import 'package:prop/utils/network_address.dart';
 
@@ -77,5 +78,47 @@ void main() {
 
     expect(diag.toText(), contains('Discovered on network:'));
     expect(diag.toText(), contains('(skipped)'));
+  });
+
+  group('mDNS queries received', () {
+    DebugDiagnostics withQueries(List<MdnsQueryLogEntry> queries) => DebugDiagnostics(
+          advertised: const [],
+          backend: 'responder',
+          hostLabel: 'bikecontrol-3f2a',
+          holdsMulticastLock: false,
+          discovered: const [],
+          discoveryRan: false,
+          addressReport: const AddressPickReport(chosen: null, candidates: []),
+          servers: const [],
+          permissions: const PermissionsSnapshot(localNetworkInferred: null),
+          recentQueries: queries,
+        );
+
+    test('renders each query with its source, QU bit and how it was answered', () {
+      final text = withQueries([
+        MdnsQueryLogEntry(
+          at: DateTime(2026, 7, 30, 9, 41, 12),
+          source: '192.168.178.92',
+          sourcePort: 5353,
+          wantsUnicast: true,
+          questions: const ['PTR _wahoo-fitness-tnp._tcp.local'],
+          answeredUnicast: true,
+          answeredMulticast: true,
+        ),
+      ]).toText();
+
+      expect(text, contains('mDNS queries received:'));
+      expect(text, contains('192.168.178.92:5353'));
+      expect(text, contains('QU'));
+      expect(text, contains('PTR _wahoo-fitness-tnp._tcp.local'));
+      expect(text, contains('unicast+multicast'));
+    });
+
+    test('says so when nothing has queried us', () {
+      // The decisive line for "the trainer app on this machine cannot see
+      // BikeControl": if no query ever arrived, the problem is upstream of our
+      // responder, not in how we answer.
+      expect(withQueries(const []).toText(), contains('(none)'));
+    });
   });
 }


### PR DESCRIPTION
## Problem

Trainer apps on the **same Windows machine** as BikeControl frequently never see the advertisement, while the identical advertisement is found without trouble from another machine. Roughly two dozen reports.

## Root cause (prop side)

Our mDNS responder answered a QU (unicast-response) question by unicast only. On Windows both processes hold `0.0.0.0:5353` through `SO_REUSEADDR`, and [Microsoft documents](https://learn.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse) that delivery to such a shared port is non-deterministic — *"the application will be unable to determine which of the two sockets received specific packets sent to the 'shared' port"* — with one documented exception: *"If two sockets are bound to the same interface and port and are members of the same multicast group, data will be delivered to **both** sockets."*

So the answer was a coin flip. macOS is unaffected because one daemon owns 5353 and fans answers out to every Bonjour client. It also explains the field workaround of running `tnc <host>.local` first: that elicits a plain QM query, whose multicast answer every socket in the group receives.

RFC 6762 §5.4 already prefers multicast here, so we were violating a SHOULD in the one way that is fatal on Windows.

Fix lives in OpenBikeControl/prop#1; this PR bumps the submodule.

## This repo

Adds the **"mDNS queries received"** section to the diagnostics report, listing each query the responder saw with its source, the QU bit, and whether the reply went out unicast, multicast, both or not at all.

This is the missing half of diagnosing "the trainer app on this machine can't find BikeControl". A same-host querier shows up with the advertised address as its source, so the report now distinguishes three very different situations:

| What the log shows | Diagnosis |
| --- | --- |
| no entries at all | the app never queried — failure is upstream of our responder |
| `PTR`/`SRV` queries | it's browsing; check whether we answered |
| `A bikecontrol-xxxx.local` queries | browse works, the **resolve** step is failing |

Empty on iOS, where the OS responder handles queries and never reports them to us.

## Still unconfirmed

Whether the trainer app's Windows browse actually sets QU, and whether its failing step is the browse or the resolve. A separate report implicates Tailscale's DNS override, which breaks `.local` through `GetAddrInfo`; `INSTRUCTIONS_WINDOWS_IPV6.md` fits that side too. The new query log is what settles it — left that file untouched until a reporter's log comes back.

## Tests

- prop: 483/483 pass, `flutter analyze lib/mdns` clean.
- app: 2 new diagnostics tests pass. Remaining full-suite failures are baseline, verified by stashing both repos (baseline −26): `screenshot_test.dart` fails 26/32 in isolation, and the snapshot tests fail on the known `MissingPluginException ... com.llfbandit.app_links/events` co-run flake. Neither references any changed code.

## Not included

No `CHANGELOG.md` entry — 6.3.0 is already cut and I didn't want to presume a 6.4 heading or a patch note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PanTG9kRBi4QTQ2psvpTxP