### PR TITLE
ci(patch): make platform selection work like the build pipeline

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -3,6 +3,14 @@ name: "Patch"
 on:
   workflow_dispatch:
     inputs:
+      build_mac:
+        # Selecting this currently only installs the signing certificates: the
+        # macOS patch step itself stays disabled until
+        # https://github.com/OpenBikeControl/bikecontrol/issues/143 is fixed.
+        description: 'Patch for macOS (patch step disabled, see #143)'
+        required: false
+        default: false
+        type: boolean
       build_windows:
         description: 'Patch for Windows'
         required: false
@@ -50,6 +58,9 @@ jobs:
   build:
     name: Patch iOS, Android & macOS
     needs: guard
+    # Without this, a Windows-only patch still spun up a macOS runner that
+    # checked out, installed Shorebird and Flutter, then ran no patch step.
+    if: inputs.build_mac || inputs.build_android || inputs.build_ios
     runs-on: macos-26
 
     permissions:
@@ -140,12 +151,15 @@ jobs:
           release-version: ${{ inputs.release_version }}
           args: '--track beta --allow-asset-diffs --allow-native-diffs --split-debug-info=symbols -- --dart-define=VERIFYING_SHARED_SECRET=${{ secrets.VERIFYING_SHARED_SECRET }} --dart-define=REVENUECAT_API_KEY_IOS=${{ secrets.REVENUECAT_API_KEY_IOS }} --dart-define=SUPABASE_ANON_KEY=${{ secrets.SUPABASE_ANON_KEY }}'
 
+      # build_mac is deliberately not part of these conditions: the macOS patch
+      # step is disabled (#143), so a macOS-only run produces no symbols/ and
+      # the zip would fail. Add it back when that patch step is re-enabled.
       - name: Zip Symbols
-        if: inputs.build_android || inputs.build_ios || inputs.build_mac
+        if: inputs.build_android || inputs.build_ios
         run: zip -P "${{ secrets.ZIP_PASSWORD }}" -r symbols.zip symbols/
 
       - name: Upload Symbols
-        if: inputs.build_android || inputs.build_ios || inputs.build_mac
+        if: inputs.build_android || inputs.build_ios
         uses: actions/upload-artifact@v4
         with:
           overwrite: true


### PR DESCRIPTION
## Problem

`patch.yml` referenced `inputs.build_mac` in three places but **never declared it** as a workflow input, so it always evaluated falsy:

```
$ grep -oE "inputs\.[a-z_]+" .github/workflows/patch.yml | sort -u
inputs.build_android
inputs.build_ios
inputs.build_mac      # <-- never declared
inputs.build_windows
inputs.release_version
inputs.track
```

Separately, the macOS-runner `build` job had no `if:`. Dispatching a **Windows-only** patch still spun up a `macos-26` runner that checked out the repo with submodules, installed Shorebird and Flutter, then ran no patch step at all.

## Changes

- **Declare `build_mac`**, mirroring `build.yml`'s per-platform booleans. Default `false`, and since the macOS patch step is still disabled by #143 the toggle only drives certificate install today — the description says so rather than implying macOS gets patched.
- **Gate the macOS-runner job** on the platforms it serves: `if: inputs.build_mac || inputs.build_android || inputs.build_ios`.
- **Symbol zip/upload keep gating on `android || ios` only.** With the macOS patch step disabled, a macOS-only run produces no `symbols/` and `zip -r symbols.zip symbols/` would fail — adding `build_mac` there would have introduced a new failure mode. Noted inline for whoever re-enables #143.

Input parity with `build.yml` is now: `build_mac`, `build_windows`, `build_android`, `build_ios` (`build.yml` additionally has `build_github`, which has no patch equivalent).

## Verification

Both workflows parse, and neither has a dangling or unused input any more:

```
.github/workflows/patch.yml
  undeclared but used: none
  declared but unused: none
.github/workflows/build.yml
  undeclared but used: none
  declared but unused: none
```

`actionlint` isn't installed locally, so that check didn't run.

## Note

Unrelated to this change, but `release_version` is a free-text string interpolated into the Shorebird `args:` strings. It's `workflow_dispatch`-only so it takes repo write access to reach, but it is an injection surface if you ever want to tighten it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PanTG9kRBi4QTQ2psvpTxP