### PR TITLE
diag: show repeat counts in the mDNS query log; bump prop submodule

### DIFF
--- a/lib/services/debug_diagnostics.dart
+++ b/lib/services/debug_diagnostics.dart
@@ -183,9 +183,12 @@ class DebugDiagnostics {
     } else {
       for (final q in recentQueries) {
         final at = q.at.toIso8601String().split('T').last.split('.').first;
+        // Repeats are folded; the count keeps a continuous poller visible as
+        // one line instead of hiding that it fired hundreds of times.
+        final repeats = q.count > 1 ? ' ×${q.count}' : '';
         b.writeln(
           '    $at ${q.source}:${q.sourcePort} ${q.wantsUnicast ? 'QU' : 'QM'} '
-          '${q.questions.join(', ')} → ${q.reply}',
+          '${q.questions.join(', ')} → ${q.reply}$repeats',
         );
       }
     }

--- a/test/services/debug_diagnostics_test.dart
+++ b/test/services/debug_diagnostics_test.dart
@@ -114,6 +114,40 @@ void main() {
       expect(text, contains('unicast+multicast'));
     });
 
+    test('marks a folded entry with its repeat count', () {
+      final text = withQueries([
+        MdnsQueryLogEntry(
+          at: DateTime(2026, 7, 30, 20, 32, 33),
+          source: '172.20.176.1',
+          sourcePort: 5353,
+          wantsUnicast: false,
+          questions: const ['PTR _oculusal_sp._tcp.local'],
+          answeredUnicast: false,
+          answeredMulticast: false,
+          count: 17,
+        ),
+      ]).toText();
+
+      expect(text, contains('×17'));
+      expect(text, contains('no answer'));
+    });
+
+    test('a single occurrence carries no count marker', () {
+      final text = withQueries([
+        MdnsQueryLogEntry(
+          at: DateTime(2026, 7, 30, 20, 32, 38),
+          source: '192.168.0.87',
+          sourcePort: 5353,
+          wantsUnicast: true,
+          questions: const ['PTR _openbikecontrol._tcp.local'],
+          answeredUnicast: true,
+          answeredMulticast: false,
+        ),
+      ]).toText();
+
+      expect(text, isNot(contains('×')));
+    });
+
     test('says so when nothing has queried us', () {
       // The decisive line for "the trainer app on this machine cannot see
       // BikeControl": if no query ever arrived, the problem is upstream of our


### PR DESCRIPTION
## Why

Tester feedback on 6.3.0+22 (the build with the QU fix from #372): **still failing, `tnc` still required.** Their diagnostics changed the diagnosis.

### The mDNS exchange is working end-to-end

```
20:32:38 ... QU  PTR _openbikecontrol._tcp.local              → unicast+multicast
20:32:38 ... QM  SRV BikeControl._openbikecontrol._tcp.local  → multicast
20:32:38 ... QM  TXT BikeControl._openbikecontrol._tcp.local  → multicast
```

MyWhoosh could only ask for `SRV BikeControl._openbikecontrol._tcp.local` if it had already received and parsed our PTR answer — that instance name came from us. **The browse succeeded.** It then got SRV and TXT, and our SRV response carries the A record as an additional, so it had PTR + SRV + TXT + A and still showed no dialog until `tnc`.

So the shared-port/QU fix is not what blocks this tester. It may be why the browse worked here at all — before it, all three interface copies would have been unicast-only — but that counterfactual isn't provable from this capture. The failure is **downstream of discovery**, consistent with MyWhoosh resolving the SRV target through the Windows resolver (`GetAddrInfo`) rather than using the A record we hand it. Tailscale is present on this machine (`100.111.140.105`), which is the known way `.local` resolution breaks.

### The log couldn't answer the remaining question

No A-record query appears anywhere in the capture — the single most informative fact — and I can't tell whether none was sent or the window was simply too short. It covered eight seconds; the `tnc` at `20:33:30` and the connect at `20:33:35` had aged out.

## Changes

Renders `×N` on folded entries so a continuous poller reads as one line that fired N times. Single occurrences stay unmarked. Picks up the prop-side fold + ceiling raise (OpenBikeControl/prop#2).

## Also visible in the capture — not a code change

MyWhoosh browses for **both** services and we answer only one:

```
20:32:39 ... QM PTR _openbikecontrol._tcp.local    → multicast
20:32:39 ... QM PTR _wahoo-fitness-tnp._tcp.local  → no answer
```

This tester is on the OpenBikeControl method, so we advertise `_openbikecontrol._tcp` only. Worth having them retry with the Wahoo/Network connection method — MyWhoosh's native trainer path, which may not depend on the same resolve step.

## Tests

prop 487/487, app services 64/64, `flutter analyze` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PanTG9kRBi4QTQ2psvpTxP